### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/haneniznet/708db97b-98bb-45e3-bbfe-eb9a8e99027e/b2a70185-fbb0-4197-ac4b-cf654523b74d/_apis/work/boardbadge/fea3f9a9-c81e-4237-9bf0-48190e51086f)](https://dev.azure.com/haneniznet/708db97b-98bb-45e3-bbfe-eb9a8e99027e/_boards/board/t/b2a70185-fbb0-4197-ac4b-cf654523b74d/Microsoft.RequirementCategory)
 # cod33
 Read Me --------------
 First


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/haneniznet/708db97b-98bb-45e3-bbfe-eb9a8e99027e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.